### PR TITLE
解压支持symlink类型

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -118,10 +118,10 @@ exports.makeUncompressFn = StreamClass => {
                   done();
                 });
               });
-            } else if(header.type==='symlink'){
+            } else if (header.type === 'symlink') {
               const fullpath = path.join(destDir, header.name);
-              fs.symlinkSync(header.linkname,fullpath);
-            } else{ // directory
+              fs.symlinkSync(header.linkname, fullpath);
+            } else { // directory
               mkdirp(path.join(destDir, header.name), err => {
                 if (err) return reject(err);
                 stream.resume();
@@ -137,12 +137,12 @@ exports.streamToBuffer = stream => {
   return new Promise((resolve, reject) => {
     const chunks = [];
     stream
-    .on('readable', () => {
-      let chunk;
-      while ((chunk = stream.read())) chunks.push(chunk);
-    })
-    .on('end', () => resolve(Buffer.concat(chunks)))
-    .on('error', err => reject(err));
+      .on('readable', () => {
+        let chunk;
+        while ((chunk = stream.read())) chunks.push(chunk);
+      })
+      .on('end', () => resolve(Buffer.concat(chunks)))
+      .on('error', err => reject(err));
   });
 };
 


### PR DESCRIPTION
解压支持symlink类型

[#57 linux (ubuntu) 下软连接文件解压时会被变成空目录](https://github.com/node-modules/compressing/issues/57)