### PR TITLE
fix: suppressSizeWarning doesn't work for tgz.Stream

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,8 @@ export namespace gzip {
 
 export namespace tar {
 
+  import StreamSizeOptions = tgz.StreamSizeOptions
+
   function compressFile(source: sourceType, dest: destType, opts?: any): Promise<void>
 
   function compressDir(source: sourceType, dest: destType, opts?: any): Promise<void>
@@ -71,10 +73,8 @@ export namespace tar {
 
     constructor(opts?: {
       relativePath?: string,
-      size?: number,
-      suppressSizeWarning?: boolean,
       source?: sourceType
-    });
+    } & StreamSizeOptions);
 
   }
 
@@ -103,22 +103,25 @@ export namespace tgz {
 
   export class Stream extends ReadStream {
 
-    constructor();
+    constructor(opts?: StreamSizeOptions);
 
     addEntry(entry: string, opts?: streamEntryOpts): void
 
     addEntry(entry: Buffer | ReadStream, opts: streamEntryOpts): void
   }
 
+  export interface StreamSizeOptions {
+    suppressSizeWarning?: boolean,
+    size?: number,
+  }
+
   export class FileStream extends ReadStream {
 
     constructor(opts?: {
       relativePath?: string,
-      size?: number,
-      suppressSizeWarning?: boolean,
       zlib?: object,
       source?: sourceType
-    });
+    } & StreamSizeOptions);
 
   }
 

--- a/lib/tar/file_stream.js
+++ b/lib/tar/file_stream.js
@@ -45,7 +45,7 @@ class TarFileStream extends stream.Transform {
         });
       } else {
         if (!opts.suppressSizeWarning) {
-          console.warn('You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.supressSizeWarning: true to suppress this warning');
+          console.warn('You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.suppressSizeWarning: true to suppress this warning');
         }
         const buf = [];
         this.entry = new stream.Writable({

--- a/lib/tar/stream.js
+++ b/lib/tar/stream.js
@@ -101,7 +101,7 @@ class TarStream extends BaseStream {
       entry.pipe(entryStream);
     } else {
       if (!opts.suppressSizeWarning) {
-        console.warn('You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.supressSizeWarning: true to suppress this warning');
+        console.warn('You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.suppressSizeWarning: true to suppress this warning');
       }
       const buf = [];
       const collectStream = new stream.Writable({

--- a/lib/tgz/stream.js
+++ b/lib/tgz/stream.js
@@ -8,7 +8,8 @@ class TgzStream extends BaseStream {
   constructor(opts) {
     super(opts);
 
-    const tarStream = this._tarStream = new tar.Stream();
+    const { suppressSizeWarning, size } = opts || {};
+    const tarStream = this._tarStream = new tar.Stream({ suppressSizeWarning, size });
     tarStream.on('error', err => this.emit('error', err));
 
     const gzipStream = new gzip.FileStream();

--- a/test/tar/file_stream.test.js
+++ b/test/tar/file_stream.test.js
@@ -18,7 +18,7 @@ describe('test/tar/file_stream.test.js', () => {
     console.log('dest', destFile);
 
     mm(console, 'warn', msg => {
-      assert(msg === 'You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.supressSizeWarning: true to suppress this warning');
+      assert(msg === 'You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.suppressSizeWarning: true to suppress this warning');
     });
 
     const fileStream = fs.createWriteStream(destFile);

--- a/test/tar/index.test.js
+++ b/test/tar/index.test.js
@@ -69,7 +69,7 @@ describe('test/tar/index.test.js', () => {
       console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       mm(console, 'warn', msg => {
-        assert(msg === 'You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.supressSizeWarning: true to suppress this warning');
+        assert(msg === 'You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.suppressSizeWarning: true to suppress this warning');
       });
       yield compressing.tar.compressFile(sourceStream, fileStream, { relativePath: 'xx.log' });
       assert(fs.existsSync(destFile));

--- a/test/tar/stream.test.js
+++ b/test/tar/stream.test.js
@@ -130,7 +130,7 @@ describe('test/tar/stream.test.js', () => {
     console.log('dest', destFile);
 
     mm(console, 'warn', msg => {
-      assert(msg === 'You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.supressSizeWarning: true to suppress this warning');
+      assert(msg === 'You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.suppressSizeWarning: true to suppress this warning');
     });
 
     const tarStream = new TarStream();

--- a/test/tgz/stream.test.js
+++ b/test/tgz/stream.test.js
@@ -189,4 +189,19 @@ describe('test/tgz/stream.test.js', () => {
     });
   });
 
+  it('.ctor(opts)', done => {
+    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const fileStream = fs.createWriteStream(destFile);
+    console.log('dest', destFile);
+
+    mm(console, 'warn', () => {});
+
+    const tgzStream = new TgzStream();
+    tgzStream.addEntry(fs.createReadStream(path.join(__dirname, '..', 'fixtures', 'xx.log')), { relativePath: 'xx.log' });
+    pump(tgzStream, fileStream, err => {
+      assert(!err);
+      assert(console.warn.called === undefined);
+      done();
+    });
+  });
 });

--- a/test/tgz/stream.test.js
+++ b/test/tgz/stream.test.js
@@ -130,7 +130,7 @@ describe('test/tgz/stream.test.js', () => {
     console.log('dest', destFile);
 
     mm(console, 'warn', msg => {
-      assert(msg === 'You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.supressSizeWarning: true to suppress this warning');
+      assert(msg === 'You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.suppressSizeWarning: true to suppress this warning');
     });
 
     const tgzStream = new TgzStream();

--- a/test/zip/stream.test.js
+++ b/test/zip/stream.test.js
@@ -129,7 +129,7 @@ describe('test/zip/stream.test.js', () => {
     console.log('dest', destFile);
 
     mm(console, 'warn', msg => {
-      assert(msg === 'You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.supressSizeWarning: true to suppress this warning');
+      assert(msg === 'You should specify the size of streamming data by opts.size to prevent all streaming data from loading into memory. If you are sure about memory cost, pass opts.suppressSizeWarning: true to suppress this warning');
     });
 
     const zipStream = new ZipStream();


### PR DESCRIPTION
close #70 

* fix typo: supress -> suppress
* pass `suppressSizeWarning` and `size` to internal `tar.Stream`