### PR TITLE
fix: throw error when source is not exists

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -78,8 +78,10 @@ exports.makeUncompressFn = StreamClass => {
   return (source, destDir, opts) => {
     opts = opts || {};
     opts.source = source;
-    if (source === undefined) {
-      throw new TypeError('uncompress source connot be undefined');
+    if (!source) { // !source 和 sourceType中返回undeined对应
+      const error = new Error('Type is not supported, must be a file path, file buffer, or a readable stream');
+      error.name = 'IlligalSourceError';
+      throw error;
     }
     if (destType(destDir) !== 'path') {
       const error = new Error('uncompress destination must be a directory');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -78,6 +78,9 @@ exports.makeUncompressFn = StreamClass => {
   return (source, destDir, opts) => {
     opts = opts || {};
     opts.source = source;
+    if (source === undefined) {
+      throw new TypeError('uncompress source connot be undefined');
+    }
     if (destType(destDir) !== 'path') {
       const error = new Error('uncompress destination must be a directory');
       error.name = 'IlligalDestError';

--- a/test/zip/uncompress_stream.test.js
+++ b/test/zip/uncompress_stream.test.js
@@ -237,7 +237,8 @@ it('should emit error if uncompress source is undefined', done => {
       .finally(() => clearTimeout(timeout));
   }catch(err) {
     clearTimeout(timeout);
-    assert(err.message === 'uncompress source connot be undefined');
+    assert(err.name === 'IlligalSourceError');
+    assert(err.message === 'Type is not supported, must be a file path, file buffer, or a readable stream');
     done();
   }
 })

--- a/test/zip/uncompress_stream.test.js
+++ b/test/zip/uncompress_stream.test.js
@@ -227,3 +227,17 @@ describe('test/zip/uncompress_stream.test.js', () => {
     });
   });
 });
+
+it('should emit error if uncompress source is undefined', done => {
+  const timeout = setTimeout(()=>{
+    done("uncompress timeout");
+  }, 1000);
+  try {
+    compressing.zip.uncompress(undefined, originalDir)
+      .finally(() => clearTimeout(timeout));
+  }catch(err) {
+    clearTimeout(timeout);
+    assert(err.message === 'uncompress source connot be undefined');
+    done();
+  }
+})


### PR DESCRIPTION
compressing.zip.uncompress 的source传入undefined时既不报错也不响应