### PR TITLE
feat: use @eggjs/yauzl to close Buffer() is deprecated message

### DIFF
--- a/lib/zip/uncompress_stream.js
+++ b/lib/zip/uncompress_stream.js
@@ -2,7 +2,7 @@
 
 // https://github.com/thejoshwolfe/yauzl#no-streaming-unzip-api
 
-const yauzl = require('yauzl');
+const yauzl = require('@eggjs/yauzl');
 const stream = require('stream');
 const UncompressBaseStream = require('../base_write_stream');
 const utils = require('../utils');

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "pump": "^3.0.0",
     "streamifier": "^0.1.1",
     "tar-stream": "^1.5.2",
-    "yauzl": "^2.7.0",
+    "@eggjs/yauzl": "^2.11.0",
     "yazl": "^2.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
closes https://github.com/node-modules/compressing/issues/84

https://github.com/node-modules/yauzl/pull/1