### PR TITLE
fix(yauzl): symlink creation on uncompressing zip files

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/node-modules/compressing#readme",
   "dependencies": {
+    "@eggjs/yauzl": "^2.11.0",
     "flushwritable": "^1.0.0",
     "get-ready": "^1.0.0",
     "iconv-lite": "^0.5.0",
@@ -46,7 +47,7 @@
     "pump": "^3.0.0",
     "streamifier": "^0.1.1",
     "tar-stream": "^1.5.2",
-    "@eggjs/yauzl": "^2.11.0",
+    "yauzl-promise": "^4.0.0",
     "yazl": "^2.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes: #99 

Since this only happens on _some_ MacOS environments, the only thing I could think of was using `yauzl-promise`  instead of `@eggjs/yauzl` which claims to fix MacOS Archive Utility issues (which seem to be the root of the problem).