### PR TITLE
fix: support windows directory detect

### DIFF
--- a/lib/zip/uncompress_stream.js
+++ b/lib/zip/uncompress_stream.js
@@ -99,7 +99,7 @@ class ZipUncompressStream extends UncompressBaseStream {
           }
         }
         // directory file names end with '/'
-        const type = /\/$/.test(entry.fileName) ? 'directory' : 'file';
+        const type = /[\\\/]$/.test(entry.fileName) ? 'directory' : 'file';
         const name = entry.fileName = this[STRIP_NAME](entry.fileName, type);
 
         const header = { name, type, yauzl: entry, mode };

--- a/lib/zip/uncompress_stream.js
+++ b/lib/zip/uncompress_stream.js
@@ -98,7 +98,7 @@ class ZipUncompressStream extends UncompressBaseStream {
             entry.fileName = iconv.decode(entry.fileName, this._zipFileNameEncoding);
           }
         }
-        // directory file names end with '/'
+        // directory file names end with '/' (for Linux and macOS) or '\' (for Windows)
         const type = /[\\\/]$/.test(entry.fileName) ? 'directory' : 'file';
         const name = entry.fileName = this[STRIP_NAME](entry.fileName, type);
 


### PR DESCRIPTION
fix window file separator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved directory detection in zip files to handle both backslashes and forward slashes, ensuring better compatibility across different operating systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->