### PR TITLE
fix: should handle ./ relative path

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -168,6 +168,13 @@ function safePipe(streams) {
 
 exports.safePipe = safePipe;
 
+function normalizePath(fileName) {
+  fileName = path.normalize(fileName);
+  // https://nodejs.org/api/path.html#path_path_normalize_path
+  if (process.platform === 'win32') fileName = fileName.replace(/\\+/g, '/');
+  return fileName;
+}
+
 exports.stripFileName = (strip, fileName, type) => {
   // before
   // node/package.json
@@ -189,15 +196,18 @@ exports.stripFileName = (strip, fileName, type) => {
   // /foo => foo
   if (fileName[0] === '/') fileName = fileName.replace(/^\/+/, '');
 
+  // fix case
+  // ./foo/bar => foo/bar
+  if (fileName) {
+    fileName = normalizePath(fileName);
+  }
+
   let s = fileName.split('/');
 
   // fix relative path
   // foo/../bar/../../asdf/
   //  => asdf/
   if (s.indexOf('..') !== -1) {
-    fileName = path.normalize(fileName);
-    // https://npm.taobao.org/mirrors/node/latest/docs/api/path.html#path_path_normalize_path
-    if (process.platform === 'win32') fileName = fileName.replace(/\\+/g, '/');
     // replace '../' on ../../foo/bar
     fileName = fileName.replace(/(\.\.\/)+/, '');
     if (type === 'directory' && fileName && fileName[fileName.length - 1] !== '/') {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -52,6 +52,10 @@ describe('test/utils.test.js', () => {
       assert(utils.stripFileName(0, '/home/../../../foo.txt', 'file') === 'foo.txt');
       assert(utils.stripFileName(0, '///../../../../foo', 'file') === 'foo');
       assert(utils.stripFileName(0, '../../../../etc/hosts', 'file') === 'etc/hosts');
+
+      assert(utils.stripFileName(0, './etc/hosts', 'file') === 'etc/hosts');
+      assert(utils.stripFileName(0, './././etc/hosts', 'file') === 'etc/hosts');
+      assert(utils.stripFileName(1, './././etc/hosts', 'file') === 'hosts');
     });
 
     it('should replace \\', () => {


### PR DESCRIPTION
We have a tgz its entry path is `./foo/bar`, and when invoke `stripFileName(1, './foo/bar')`, it always return `foo/bar`, actually, we expect it to return `bar`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of file paths to ensure consistent formatting across different operating systems.

- **Tests**
  - Added new test cases to verify correct behavior when normalizing and stripping relative file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->