### PR TITLE
chore: replace var with let/const in isRealPathSafe

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,14 +36,14 @@ function isRealPathSafe(targetPath, parentDir, realParentDir, callback) {
     return isPathWithinParent(p, parentDir) || isPathWithinParent(p, realParentDir);
   }
 
-  var relative = path.relative(parentDir, targetPath);
-  var segments = relative.split(path.sep);
-  var i = 0;
-  var current = parentDir;
+  const relative = path.relative(parentDir, targetPath);
+  const segments = relative.split(path.sep);
+  let i = 0;
+  let current = parentDir;
 
   function checkNext() {
     if (i >= segments.length) return callback(null, true);
-    var segment = segments[i++];
+    const segment = segments[i++];
     if (!segment || segment === '.') return checkNext();
 
     current = path.join(current, segment);
@@ -61,7 +61,7 @@ function isRealPathSafe(targetPath, parentDir, realParentDir, callback) {
             // Dangling symlink - check textual target
             return fs.readlink(current, function(err, linkTarget) {
               if (err) return callback(null, false);
-              var absTarget = path.resolve(path.dirname(current), linkTarget);
+              const absTarget = path.resolve(path.dirname(current), linkTarget);
               callback(null, isWithinParent(absTarget));
             });
           }


### PR DESCRIPTION
## Summary
- Replace `var` with `let`/`const` in `isRealPathSafe()` in `lib/utils.js` to fix 6 eslint `no-var` errors introduced by the GHSA-4c3q-x735-j3r5 fix.

## Test plan
- [x] `npm run lint` passes with 0 errors