### PR TITLE
test: use node:crypto randomUUID instead of uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "eslint-config-egg": "12",
     "mm": "^2.0.0",
     "mz-modules": "^2.1.0",
-    "typescript": "5",
-    "uuid": "^3.0.1"
+    "typescript": "5"
   },
   "engines": {
     "node": ">= 18.0.0"

--- a/test/gzip/file_stream.test.js
+++ b/test/gzip/file_stream.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const { pipeline: pump } = require('stream');
 const compressing = require('../..');
 const assert = require('assert');
@@ -10,7 +10,7 @@ describe('test/gzip/file_stream.test.js', () => {
   it('should be a transform stream', done => {
     const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
     const sourceStream = fs.createReadStream(sourceFile);
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.log.gz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.log.gz');
     // console.log('destFile', destFile);
     const gzipStream = new compressing.gzip.FileStream();
     const destStream = fs.createWriteStream(destFile);
@@ -23,7 +23,7 @@ describe('test/gzip/file_stream.test.js', () => {
 
   it('should compress according to file path', done => {
     const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.log.gz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.log.gz');
     // console.log('destFile', destFile);
     const gzipStream = new compressing.gzip.FileStream({ source: sourceFile });
     const destStream = fs.createWriteStream(destFile);
@@ -42,7 +42,7 @@ describe('test/gzip/file_stream.test.js', () => {
       gzipChunks.push(chunk);
     }
 
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.log.gz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.log.gz');
     await fs.promises.writeFile(destFile, Buffer.concat(gzipChunks));
     // console.log(destFile);
   });
@@ -50,7 +50,7 @@ describe('test/gzip/file_stream.test.js', () => {
   it('should compress buffer', done => {
     const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
     const sourceBuffer = fs.readFileSync(sourceFile);
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.log.gz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.log.gz');
     // console.log('destFile', destFile);
     const destStream = fs.createWriteStream(destFile);
     const gzipStream = new compressing.gzip.FileStream({ source: sourceBuffer });
@@ -65,7 +65,7 @@ describe('test/gzip/file_stream.test.js', () => {
   it('should compress stream', done => {
     const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
     const sourceStream = fs.createReadStream(sourceFile);
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.log.gz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.log.gz');
     // console.log('destFile', destFile);
     const destStream = fs.createWriteStream(destFile);
     const gzipStream = new compressing.gzip.FileStream({ source: sourceStream });

--- a/test/gzip/index.test.js
+++ b/test/gzip/index.test.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const compressing = require('../..');
 const assert = require('assert');
 const isWindows = os.platform() === 'win32';
@@ -12,7 +12,7 @@ describe('test/gzip/index.test.js', () => {
   describe('gzip.compressFile()', () => {
     it('gzip.compressFile(file, stream)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.log.gz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.log.gz');
       // console.log('destFile', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.gzip.compressFile(sourceFile, fileStream);
@@ -21,7 +21,7 @@ describe('test/gzip/index.test.js', () => {
 
     it('gzip.compressFile(file, destStream) should error if destStream emit error', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.gz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.gz');
       const fileStream = fs.createWriteStream(destFile);
       setImmediate(() => fileStream.emit('error', new Error('xx')));
 
@@ -37,7 +37,7 @@ describe('test/gzip/index.test.js', () => {
     it('gzip.compressFile(buffer, stream)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
       const sourceBuffer = fs.readFileSync(sourceFile);
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.log.gz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.log.gz');
       // console.log('destFile', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.gzip.compressFile(sourceBuffer, fileStream);
@@ -47,7 +47,7 @@ describe('test/gzip/index.test.js', () => {
     it('gzip.compressFile(sourceStream, destStream)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
       const sourceStream = fs.createReadStream(sourceFile);
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.log.gz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.log.gz');
       // console.log('destFile', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.gzip.compressFile(sourceStream, fileStream);
@@ -59,7 +59,7 @@ describe('test/gzip/index.test.js', () => {
     it('gzip.uncompress(sourceFile, destStream)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log.gz');
       const originalFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.log');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.log');
       const fileStream = fs.createWriteStream(destFile);
       await compressing.gzip.uncompress(sourceFile, fileStream);
       assert(fs.existsSync(destFile));
@@ -72,7 +72,7 @@ describe('test/gzip/index.test.js', () => {
     it('gzip.uncompress(sourceStream, destStream)', async () => {
       const sourceStream = fs.createReadStream(path.join(__dirname, '..', 'fixtures', 'xx.log.gz'));
       const originalFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.log');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.log');
       const fileStream = fs.createWriteStream(destFile);
       await compressing.gzip.uncompress(sourceStream, fileStream);
       assert(fs.existsSync(destFile));
@@ -85,7 +85,7 @@ describe('test/gzip/index.test.js', () => {
     it('gzip.uncompress(sourceStream, destFile)', async () => {
       const sourceStream = fs.createReadStream(path.join(__dirname, '..', 'fixtures', 'xx.log.gz'));
       const originalFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.log');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.log');
       await compressing.gzip.uncompress(sourceStream, destFile);
       assert(fs.existsSync(destFile));
       if (!isWindows) {
@@ -97,7 +97,7 @@ describe('test/gzip/index.test.js', () => {
     it('gzip.uncompress(sourceFile, destFile)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log.gz');
       const originalFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.log');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.log');
       await compressing.gzip.uncompress(sourceFile, destFile);
       assert(fs.existsSync(destFile));
       if (!isWindows) {
@@ -109,7 +109,7 @@ describe('test/gzip/index.test.js', () => {
     it('gzip.uncompress(buffer, destFile)', async () => {
       const sourceBuffer = fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'xx.log.gz'));
       const originalFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.log');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.log');
       await compressing.gzip.uncompress(sourceBuffer, destFile);
       assert(fs.existsSync(destFile));
       if (!isWindows) {

--- a/test/gzip/uncompress_stream.test.js
+++ b/test/gzip/uncompress_stream.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const mm = require('mm');
 const os = require('os');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const path = require('path');
 const assert = require('assert');
 const { pipeline: pump } = require('stream');
@@ -16,7 +16,7 @@ describe('test/gzip/uncompress_stream.test.js', () => {
   afterEach(mm.restore);
 
   it('should be transform stream', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.log');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.log');
 
     const sourceStream = fs.createReadStream(sourceFile);
     const uncompressStream = new compressing.gzip.UncompressStream();
@@ -36,7 +36,7 @@ describe('test/gzip/uncompress_stream.test.js', () => {
   });
 
   it('should uncompress according to file path', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.log');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.log');
 
     const uncompressStream = new compressing.gzip.UncompressStream({ source: sourceFile });
     const destStream = fs.createWriteStream(destFile);
@@ -55,7 +55,7 @@ describe('test/gzip/uncompress_stream.test.js', () => {
 
   it('should uncompress buffer', done => {
     const sourceBuffer = fs.readFileSync(sourceFile);
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.log');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.log');
 
     const destStream = fs.createWriteStream(destFile);
     const uncompressStream = new compressing.gzip.UncompressStream({ source: sourceBuffer });
@@ -74,7 +74,7 @@ describe('test/gzip/uncompress_stream.test.js', () => {
 
   it('should uncompress stream', done => {
     const sourceStream = fs.createReadStream(sourceFile);
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.log');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.log');
 
     const destStream = fs.createWriteStream(destFile);
     const uncompressStream = new compressing.gzip.UncompressStream({ source: sourceStream });

--- a/test/tar/file_stream.test.js
+++ b/test/tar/file_stream.test.js
@@ -4,7 +4,7 @@ const mm = require('mm');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const assert = require('assert');
 const { pipeline: pump } = require('stream');
 const compressing = require('../..');
@@ -14,7 +14,7 @@ describe('test/tar/file_stream.test.js', () => {
   it('tar.FileStream without size', done => {
     const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
     const sourceStream = fs.createReadStream(sourceFile);
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     // console.log('dest', destFile);
 
     mm(console, 'warn', msg => {
@@ -33,7 +33,7 @@ describe('test/tar/file_stream.test.js', () => {
   it('tar.FileStream with size', done => {
     const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
     const sourceStream = fs.createReadStream(sourceFile);
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     // console.log('dest', destFile);
 
     mm(console, 'warn', msg => {

--- a/test/tar/index.test.js
+++ b/test/tar/index.test.js
@@ -4,7 +4,7 @@ const mm = require('mm');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const compressing = require('../..');
 const assert = require('assert');
 const dircompare = require('dir-compare');
@@ -15,7 +15,7 @@ describe('test/tar/index.test.js', () => {
   describe('tar.compressFile()', () => {
     it('tar.compressFile(file, stream)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.tar.compressFile(sourceFile, fileStream);
@@ -24,7 +24,7 @@ describe('test/tar/index.test.js', () => {
 
     it('tar.compressFile(file, stream, { relativePath })', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.tar.compressFile(sourceFile, fileStream, { relativePath: 'dd/dd.log' });
@@ -34,7 +34,7 @@ describe('test/tar/index.test.js', () => {
 
     it('tar.compressFile(file, stream) should error if file not exist', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'not-exist.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       let err;
@@ -49,7 +49,7 @@ describe('test/tar/index.test.js', () => {
 
     it('tar.compressFile(file, destStream) should error if destStream emit error', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       const fileStream = fs.createWriteStream(destFile);
       setImmediate(() => fileStream.emit('error', new Error('xx')));
       let err;
@@ -64,7 +64,7 @@ describe('test/tar/index.test.js', () => {
     it('tar.compressFile(sourceStream, stream)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
       const sourceStream = fs.createReadStream(sourceFile);
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       mm(console, 'warn', msg => {
@@ -77,7 +77,7 @@ describe('test/tar/index.test.js', () => {
     it('tar.compressFile(sourceStream, stream, { size })', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
       const sourceStream = fs.createReadStream(sourceFile);
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       // console.log('destFile', destFile);
       const fileStream = fs.createWriteStream(destFile);
       mm(console, 'warn', msg => {
@@ -90,7 +90,7 @@ describe('test/tar/index.test.js', () => {
     it('tar.compressFile(buffer, stream)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
       const sourceBuffer = fs.readFileSync(sourceFile);
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.tar.compressFile(sourceBuffer, fileStream, { relativePath: 'xx.log' });
@@ -100,13 +100,13 @@ describe('test/tar/index.test.js', () => {
     it('should keep stat mode', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures/xxx/bin');
       const originStat = fs.statSync(sourceFile);
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.tar.compressFile(sourceFile, fileStream);
       assert(fs.existsSync(destFile));
 
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       await fs.promises.mkdir(destDir, { recursive: true });
       await compressing.tar.uncompress(destFile, destDir);
       const stat = fs.statSync(path.join(destDir, 'bin'));
@@ -119,7 +119,7 @@ describe('test/tar/index.test.js', () => {
   describe('tar.compressDir()', () => {
     it('tar.compressDir(dir, destFile)', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       // console.log('dest', destFile);
       await compressing.tar.compressDir(sourceDir, destFile);
       assert(fs.existsSync(destFile));
@@ -127,7 +127,7 @@ describe('test/tar/index.test.js', () => {
 
     it('tar.compressDir(dir, destStream)', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       const destStream = fs.createWriteStream(destFile);
       // console.log('dest', destFile);
       await compressing.tar.compressDir(sourceDir, destStream);
@@ -136,7 +136,7 @@ describe('test/tar/index.test.js', () => {
 
     it('tar.compressDir(dir, destStream, { ignoreBase: true })', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       const destStream = fs.createWriteStream(destFile);
       // console.log('dest', destFile);
       await compressing.tar.compressDir(sourceDir, destStream, { ignoreBase: true });
@@ -145,7 +145,7 @@ describe('test/tar/index.test.js', () => {
 
     it('tar.compressDir(dir, destStream) should return promise', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       // console.log('dest', destFile);
       await compressing.tar.compressDir(sourceDir, destFile);
       assert(fs.existsSync(destFile));
@@ -153,7 +153,7 @@ describe('test/tar/index.test.js', () => {
 
     it('tar.compressDir(dir, destStream) should reject when destStream emit error', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       const destStream = fs.createWriteStream(destFile);
       // console.log('dest', destFile);
       setImmediate(() => {
@@ -187,7 +187,7 @@ describe('test/tar/index.test.js', () => {
   describe('tar.uncompress()', () => {
     it('tar.uncompress(sourceFile, destDir)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xxx.tar');
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'xxx');
       await compressing.tar.uncompress(sourceFile, destDir);
       const res = dircompare.compareSync(originalDir, path.join(destDir, 'xxx'));
@@ -199,7 +199,7 @@ describe('test/tar/index.test.js', () => {
 
     it('tar.uncompress(sourceStream, destDir)', async () => {
       const sourceStream = fs.createReadStream(path.join(__dirname, '..', 'fixtures', 'xxx.tar'));
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'xxx');
       await compressing.tar.uncompress(sourceStream, destDir);
       const res = dircompare.compareSync(originalDir, path.join(destDir, 'xxx'));
@@ -211,7 +211,7 @@ describe('test/tar/index.test.js', () => {
 
     it('tar.uncompress(sourceBuffer, destDir)', async () => {
       const sourceBuffer = fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'xxx.tar'));
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'xxx');
       // console.log('sourceBuffer', destDir, originalDir);
       await compressing.tar.uncompress(sourceBuffer, destDir);
@@ -229,7 +229,7 @@ describe('test/tar/index.test.js', () => {
 
     it('tar.uncompress(sourceFile, destDir) with strip 1', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xxx.tar');
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'xxx');
       await compressing.tar.uncompress(sourceFile, destDir, { strip: 1 });
       const res = dircompare.compareSync(originalDir, destDir);
@@ -241,7 +241,7 @@ describe('test/tar/index.test.js', () => {
 
     it('tar.uncompress(sourceFile, destDir) with strip 2', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xxx.tar');
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       await compressing.tar.uncompress(sourceFile, destDir, { strip: 2 });
       const res = dircompare.compareSync(path.join(__dirname, '..', 'fixtures', 'xxx-strip2'), destDir);
       assert.equal(res.distinct, 0);

--- a/test/tar/security-GHSA-4c3q-x735-j3r5.test.js
+++ b/test/tar/security-GHSA-4c3q-x735-j3r5.test.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const zlib = require('zlib');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const assert = require('assert');
 const compressing = require('../..');
 const { createTarBuffer } = require('../util');
@@ -13,7 +13,7 @@ describe('test/tar/security-GHSA-4c3q-x735-j3r5.test.js', () => {
   let tempDir;
 
   beforeEach(() => {
-    tempDir = path.join(os.tmpdir(), uuid.v4());
+    tempDir = path.join(os.tmpdir(), randomUUID());
     fs.mkdirSync(tempDir, { recursive: true });
   });
 

--- a/test/tar/security-GHSA-cc8f-xg8v-72m3.test.js
+++ b/test/tar/security-GHSA-cc8f-xg8v-72m3.test.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const assert = require('assert');
 const compressing = require('../..');
 const { createTarBuffer } = require('../util');
@@ -12,7 +12,7 @@ describe('test/tar/security-GHSA-cc8f-xg8v-72m3.test.js', () => {
   let tempDir;
 
   beforeEach(() => {
-    tempDir = path.join(os.tmpdir(), uuid.v4());
+    tempDir = path.join(os.tmpdir(), randomUUID());
     fs.mkdirSync(tempDir, { recursive: true });
   });
 

--- a/test/tar/stream.test.js
+++ b/test/tar/stream.test.js
@@ -4,7 +4,7 @@ const mm = require('mm');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const { pipeline: pump } = require('stream');
 const compressing = require('../..');
 const assert = require('assert');
@@ -15,7 +15,7 @@ describe('test/tar/stream.test.js', () => {
   afterEach(mm.restore);
 
   it('.addEntry(file)', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -31,7 +31,7 @@ describe('test/tar/stream.test.js', () => {
   });
 
   it('.addEntry(file, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -47,7 +47,7 @@ describe('test/tar/stream.test.js', () => {
   });
 
   it('.addEntry(dir)', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -63,7 +63,7 @@ describe('test/tar/stream.test.js', () => {
   });
 
   it('.addEntry(dir, { ignoreBase: true })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -79,7 +79,7 @@ describe('test/tar/stream.test.js', () => {
   });
 
   it('.addEntry(dir, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -95,7 +95,7 @@ describe('test/tar/stream.test.js', () => {
   });
 
   it('.addEntry(dir, { relativePath, ignoreBase: true })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -111,7 +111,7 @@ describe('test/tar/stream.test.js', () => {
   });
 
   it('.addEntry(buffer, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -125,7 +125,7 @@ describe('test/tar/stream.test.js', () => {
   });
 
   it('.addEntry(stream, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -143,7 +143,7 @@ describe('test/tar/stream.test.js', () => {
   });
 
   it('.addEntry(stream, { relativePath, size })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -164,7 +164,7 @@ describe('test/tar/stream.test.js', () => {
   it('.addEntry multiple times', done => {
     const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
     const sourceDir = path.join(__dirname, '..', 'fixtures');
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 

--- a/test/tar/symlink-resolution.test.js
+++ b/test/tar/symlink-resolution.test.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const zlib = require('zlib');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const assert = require('assert');
 const compressing = require('../..');
 const { createTarBuffer, createZipBuffer } = require('../util');
@@ -16,7 +16,7 @@ describe('test/tar/symlink-resolution.test.js', () => {
   let tempDir;
 
   beforeEach(() => {
-    tempDir = path.join(os.tmpdir(), uuid.v4());
+    tempDir = path.join(os.tmpdir(), randomUUID());
     fs.mkdirSync(tempDir, { recursive: true });
   });
 

--- a/test/tar/uncompress_stream.test.js
+++ b/test/tar/uncompress_stream.test.js
@@ -2,7 +2,7 @@ const mm = require('mm');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const assert = require('assert');
 const { pipeline: pump } = require('stream');
 const dircompare = require('dir-compare');
@@ -18,7 +18,7 @@ describe('test/tar/uncompress_stream.test.js', () => {
 
   it('should be a writable stream', done => {
     const sourceStream = fs.createReadStream(sourceFile);
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.tar.UncompressStream();
     fs.mkdirSync(destDir, { recursive: true });
@@ -48,7 +48,7 @@ describe('test/tar/uncompress_stream.test.js', () => {
   });
 
   it('should uncompress according to file path', done => {
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.tar.UncompressStream({ source: sourceFile });
     fs.mkdirSync(destDir, { recursive: true });
@@ -79,7 +79,7 @@ describe('test/tar/uncompress_stream.test.js', () => {
 
   it('should uncompress buffer', done => {
     const sourceBuffer = fs.readFileSync(sourceFile);
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.tar.UncompressStream({ source: sourceBuffer });
     fs.mkdirSync(destDir, { recursive: true });
@@ -113,7 +113,7 @@ describe('test/tar/uncompress_stream.test.js', () => {
 
   it('should uncompress stream', done => {
     const sourceStream = fs.createReadStream(sourceFile);
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.tar.UncompressStream({ source: sourceStream });
     fs.mkdirSync(destDir, { recursive: true });

--- a/test/tgz/file_stream.test.js
+++ b/test/tgz/file_stream.test.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const { pipeline: pump } = require('stream');
 const compressing = require('../..');
 const assert = require('assert');
@@ -12,7 +12,7 @@ describe('test/tgz/file_stream.test.js', () => {
   it('tgz.FileStream', done => {
     const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
     const sourceStream = fs.createReadStream(sourceFile);
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
     // console.log('dest', destFile);
     const fileStream = fs.createWriteStream(destFile);
     const tgzStream = new compressing.tgz.FileStream({ relativePath: 'dd/dd.log' });

--- a/test/tgz/index.test.js
+++ b/test/tgz/index.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const assert = require('assert');
 const dircompare = require('dir-compare');
 const compressing = require('../..');
@@ -12,7 +12,7 @@ describe('test/tgz/index.test.js', () => {
   describe('tgz.compressFile()', () => {
     it('tgz.compressFile(file, stream)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.tgz.compressFile(sourceFile, fileStream);
@@ -21,7 +21,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.compressFile(file, stream, { relativePath })', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.tgz.compressFile(sourceFile, fileStream, { relativePath: 'dd/dd.log' });
@@ -31,7 +31,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.compressFile(file, stream) should error if file not exist', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'not-exist.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
       const fileStream = fs.createWriteStream(destFile);
       let err;
       try {
@@ -45,7 +45,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.compressFile(file, destStream) should error if destStream emit error', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
       const fileStream = fs.createWriteStream(destFile);
       setImmediate(() => fileStream.emit('error', new Error('xx')));
       let err;
@@ -60,13 +60,13 @@ describe('test/tgz/index.test.js', () => {
     it('should keep stat mode', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures/xxx/bin');
       const originStat = fs.statSync(sourceFile);
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tar');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tar');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.tgz.compressFile(sourceFile, fileStream);
       assert(fs.existsSync(destFile));
 
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       await fs.promises.mkdir(destDir, { recursive: true });
       await compressing.tgz.uncompress(destFile, destDir);
       const stat = fs.statSync(path.join(destDir, 'bin'));
@@ -80,7 +80,7 @@ describe('test/tgz/index.test.js', () => {
   describe('tgz.compressDir()', () => {
     it('tgz.compressDir(dir, destFile)', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
       // console.log('dest', destFile);
       await compressing.tgz.compressDir(sourceDir, destFile);
       assert(fs.existsSync(destFile));
@@ -88,7 +88,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.compressDir(dir, destStream)', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
       const destStream = fs.createWriteStream(destFile);
       // console.log('dest', destFile);
       await compressing.tgz.compressDir(sourceDir, destStream);
@@ -97,7 +97,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.compressDir(dir, destStream, { ignoreBase: true })', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
       const destStream = fs.createWriteStream(destFile);
       // console.log('dest', destFile);
       await compressing.tgz.compressDir(sourceDir, destStream, { ignoreBase: true });
@@ -106,7 +106,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.compressDir(dir, destStream) should return promise', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
       // console.log('dest', destFile);
       await compressing.tgz.compressDir(sourceDir, destFile);
       assert(fs.existsSync(destFile));
@@ -114,7 +114,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.compressDir(dir, destStream) should reject when destStream emit error', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+      const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
       const destStream = fs.createWriteStream(destFile);
       setImmediate(() => {
         destStream.emit('error', new Error('xxx'));
@@ -147,7 +147,7 @@ describe('test/tgz/index.test.js', () => {
   describe('tgz.uncompress()', () => {
     it('tgz.uncompress(sourceFile, destDir)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xxx.tgz');
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'xxx');
       await compressing.tgz.uncompress(sourceFile, destDir);
 
@@ -173,7 +173,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.uncompress(sourceFile, destDir) with symlink', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'symlink.tgz');
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'symlink');
       await compressing.tgz.uncompress(sourceFile, destDir);
       // console.log(destDir);
@@ -200,7 +200,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.uncompress(sourceStream, destDir)', async () => {
       const sourceStream = fs.createReadStream(path.join(__dirname, '..', 'fixtures', 'xxx.tgz'));
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'xxx');
       await compressing.tgz.uncompress(sourceStream, destDir);
       const res = dircompare.compareSync(originalDir, path.join(destDir, 'xxx'));
@@ -212,7 +212,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.uncompress(sourceBuffer, destDir)', async () => {
       const sourceBuffer = fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'xxx.tgz'));
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'xxx');
       await compressing.tgz.uncompress(sourceBuffer, destDir);
       const res = dircompare.compareSync(originalDir, path.join(destDir, 'xxx'));
@@ -224,7 +224,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.uncompress(sourceFile, destDir) with strip 1', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xxx.tgz');
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'xxx');
       await compressing.tgz.uncompress(sourceFile, destDir, { strip: 1 });
       const res = dircompare.compareSync(originalDir, destDir);
@@ -236,7 +236,7 @@ describe('test/tgz/index.test.js', () => {
 
     it('tgz.uncompress(sourceFile, destDir) with strip 2', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xxx.tgz');
-      const destDir = path.join(os.tmpdir(), uuid.v4());
+      const destDir = path.join(os.tmpdir(), randomUUID());
       await compressing.tgz.uncompress(sourceFile, destDir, { strip: 2 });
       const res = dircompare.compareSync(path.join(__dirname, '..', 'fixtures', 'xxx-strip2'), destDir);
       assert.equal(res.distinct, 0);

--- a/test/tgz/stream.test.js
+++ b/test/tgz/stream.test.js
@@ -4,7 +4,7 @@ const mm = require('mm');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const { pipeline: pump } = require('stream');
 const compressing = require('../..');
 const assert = require('assert');
@@ -15,7 +15,7 @@ describe('test/tgz/stream.test.js', () => {
   afterEach(mm.restore);
 
   it('.addEntry(file)', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -31,7 +31,7 @@ describe('test/tgz/stream.test.js', () => {
   });
 
   it('.addEntry(file, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -47,7 +47,7 @@ describe('test/tgz/stream.test.js', () => {
   });
 
   it('.addEntry(dir)', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -63,7 +63,7 @@ describe('test/tgz/stream.test.js', () => {
   });
 
   it('.addEntry(dir, { ignoreBase: true })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -79,7 +79,7 @@ describe('test/tgz/stream.test.js', () => {
   });
 
   it('.addEntry(dir, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -95,7 +95,7 @@ describe('test/tgz/stream.test.js', () => {
   });
 
   it('.addEntry(dir, { relativePath, ignoreBase: true })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -111,7 +111,7 @@ describe('test/tgz/stream.test.js', () => {
   });
 
   it('.addEntry(buffer, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -125,7 +125,7 @@ describe('test/tgz/stream.test.js', () => {
   });
 
   it('.addEntry(stream, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -143,7 +143,7 @@ describe('test/tgz/stream.test.js', () => {
   });
 
   it('.addEntry(stream, { relativePath, size })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -164,7 +164,7 @@ describe('test/tgz/stream.test.js', () => {
   it('.addEntry multiple times', done => {
     const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
     const sourceDir = path.join(__dirname, '..', 'fixtures');
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.tgz');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.tgz');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 

--- a/test/tgz/uncompress_stream.test.js
+++ b/test/tgz/uncompress_stream.test.js
@@ -2,7 +2,7 @@ const mm = require('mm');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const assert = require('assert');
 const { pipeline: pump } = require('stream');
 const dircompare = require('dir-compare');
@@ -17,7 +17,7 @@ describe('test/tgz/uncompress_stream.test.js', () => {
 
   it.skip('should be a writable stream', done => {
     const sourceStream = fs.createReadStream(sourceFile);
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.tgz.UncompressStream();
     fs.mkdirSync(destDir, { recursive: true });
@@ -48,7 +48,7 @@ describe('test/tgz/uncompress_stream.test.js', () => {
   });
 
   it('should uncompress according to file path', done => {
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.tgz.UncompressStream({ source: sourceFile });
     fs.mkdirSync(destDir, { recursive: true });
@@ -80,7 +80,7 @@ describe('test/tgz/uncompress_stream.test.js', () => {
 
   it('should uncompress buffer', done => {
     const sourceBuffer = fs.readFileSync(sourceFile);
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.tgz.UncompressStream({ source: sourceBuffer });
     fs.mkdirSync(destDir, { recursive: true });
@@ -111,7 +111,7 @@ describe('test/tgz/uncompress_stream.test.js', () => {
 
   it('should uncompress stream', done => {
     const sourceStream = fs.createReadStream(sourceFile);
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.tgz.UncompressStream({ source: sourceStream });
     fs.mkdirSync(destDir, { recursive: true });

--- a/test/zip/file_stream.test.js
+++ b/test/zip/file_stream.test.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const { pipeline: pump } = require('stream');
 const compressing = require('../..');
 const assert = require('assert');
@@ -12,7 +12,7 @@ describe.skip('test/zip/file_stream.test.js', () => {
   it('zip.FileStream', done => {
     const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
     const sourceStream = fs.createReadStream(sourceFile);
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     // console.log('dest', destFile);
     const fileStream = fs.createWriteStream(destFile);
     const zipStream = new compressing.zip.FileStream({ relativePath: 'dd/dd.log' });

--- a/test/zip/index.test.js
+++ b/test/zip/index.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const assert = require('assert');
 const dircompare = require('dir-compare');
 const compressing = require('../..');
@@ -23,9 +23,9 @@ describe('test/zip/index.test.js', () => {
   describe('zip.compressFile()', () => {
     it('zip.compressFile(file, stream)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       fs.mkdirSync(destDir, { recursive: true });
-      const destFile = path.join(destDir, uuid.v4() + '.zip');
+      const destFile = path.join(destDir, randomUUID() + '.zip');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.zip.compressFile(sourceFile, fileStream);
@@ -34,9 +34,9 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.compressFile(file, stream) should handle error if file not exist', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log', 'not_exist');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       fs.mkdirSync(destDir, { recursive: true });
-      const destFile = path.join(destDir, uuid.v4() + '.zip');
+      const destFile = path.join(destDir, randomUUID() + '.zip');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       let err;
@@ -50,9 +50,9 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.compressFile(file, destStream) should error if destStream emit error', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       fs.mkdirSync(destDir, { recursive: true });
-      const destFile = path.join(destDir, uuid.v4() + '.zip');
+      const destFile = path.join(destDir, randomUUID() + '.zip');
       const fileStream = fs.createWriteStream(destFile);
       setImmediate(() => fileStream.emit('error', new Error('xx')));
       let err;
@@ -67,9 +67,9 @@ describe('test/zip/index.test.js', () => {
     it('zip.compressFile(buffer, stream)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
       const sourceBuffer = fs.readFileSync(sourceFile);
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       fs.mkdirSync(destDir, { recursive: true });
-      const destFile = path.join(destDir, uuid.v4() + '.zip');
+      const destFile = path.join(destDir, randomUUID() + '.zip');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.zip.compressFile(sourceBuffer, fileStream, { relativePath: 'dd/dd.log' });
@@ -79,9 +79,9 @@ describe('test/zip/index.test.js', () => {
     it('zip.compressFile(sourceStream, targetStream)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
       const sourceStream = fs.createReadStream(sourceFile);
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       fs.mkdirSync(destDir, { recursive: true });
-      const destFile = path.join(destDir, uuid.v4() + '.zip');
+      const destFile = path.join(destDir, randomUUID() + '.zip');
       // console.log('dest', destFile);
       const fileStream = fs.createWriteStream(destFile);
       await compressing.zip.compressFile(sourceStream, fileStream, { relativePath: 'dd/dd.log' });
@@ -92,9 +92,9 @@ describe('test/zip/index.test.js', () => {
   describe('zip.compressDir()', () => {
     it('zip.compressDir(dir, destFile)', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       fs.mkdirSync(destDir, { recursive: true });
-      const destFile = path.join(destDir, uuid.v4() + '.zip');
+      const destFile = path.join(destDir, randomUUID() + '.zip');
       // console.log('dest', destFile);
       await compressing.zip.compressDir(sourceDir, destFile);
       assert(fs.existsSync(destFile));
@@ -102,9 +102,9 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.compressDir(dir, destStream)', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       fs.mkdirSync(destDir, { recursive: true });
-      const destFile = path.join(destDir, uuid.v4() + '.zip');
+      const destFile = path.join(destDir, randomUUID() + '.zip');
       const destStream = fs.createWriteStream(destFile);
       // console.log('dest', destFile);
       await compressing.zip.compressDir(sourceDir, destStream);
@@ -113,9 +113,9 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.compressDir(dir, destStream, { ignoreBase: true })', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       fs.mkdirSync(destDir, { recursive: true });
-      const destFile = path.join(destDir, uuid.v4() + '.zip');
+      const destFile = path.join(destDir, randomUUID() + '.zip');
       const destStream = fs.createWriteStream(destFile);
       // console.log('dest', destFile);
       await compressing.zip.compressDir(sourceDir, destStream, { ignoreBase: true });
@@ -124,9 +124,9 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.compressDir(dir, destStream) should return promise', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       fs.mkdirSync(destDir, { recursive: true });
-      const destFile = path.join(destDir, uuid.v4() + '.zip');
+      const destFile = path.join(destDir, randomUUID() + '.zip');
       // console.log('dest', destFile);
       await compressing.zip.compressDir(sourceDir, destFile);
       assert(fs.existsSync(destFile));
@@ -134,9 +134,9 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.compressDir(dir, destStream) should reject when destStream emit error', async () => {
       const sourceDir = path.join(__dirname, '..', 'fixtures');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       fs.mkdirSync(destDir, { recursive: true });
-      const destFile = path.join(destDir, uuid.v4() + '.zip');
+      const destFile = path.join(destDir, randomUUID() + '.zip');
       const destStream = fs.createWriteStream(destFile);
       setImmediate(() => {
         destStream.emit('error', new Error('xxx'));
@@ -167,7 +167,7 @@ describe('test/zip/index.test.js', () => {
   describe('zip.uncompress()', () => {
     it('zip.uncompress(sourceFile, destDir)', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xxx.zip');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'xxx');
       await compressing.zip.uncompress(sourceFile, destDir);
       const res = dircompare.compareSync(originalDir, path.join(destDir, 'xxx'));
@@ -179,7 +179,7 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.uncompress(sourceFile, destDir) support file mode', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xxx.zip');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       await compressing.zip.uncompress(sourceFile, destDir, {
         mode: 32804,
       });
@@ -195,7 +195,7 @@ describe('test/zip/index.test.js', () => {
     // only test on local
     it.skip('zip.uncompress(sourceFile, destDir) support chinese gbk path', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'chinese-path-test.zip');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       await compressing.zip.uncompress(sourceFile, destDir, {
         zipFileNameEncoding: 'gbk',
       });
@@ -204,7 +204,7 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.uncompress(sourceFile, destDir) work on zipFileNameEncoding = gbk', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xxx.zip');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       await compressing.zip.uncompress(sourceFile, destDir, {
         zipFileNameEncoding: 'gbk',
         strip: 1,
@@ -214,7 +214,7 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.uncompress(sourceFile, destDir) work on zipFileNameEncoding = utf8', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xxx.zip');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       await compressing.zip.uncompress(sourceFile, destDir, {
         zipFileNameEncoding: 'utf8',
         strip: 1,
@@ -224,7 +224,7 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.uncompress(sourceFile, destDir) work on zipFileNameEncoding = utf-8', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'xxx.zip');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       await compressing.zip.uncompress(sourceFile, destDir, {
         zipFileNameEncoding: 'utf-8',
         strip: 1,
@@ -234,7 +234,7 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.uncompress(sourceFile, destDir) support absolute path', async () => {
       const sourceFile = path.join(__dirname, '..', 'fixtures', 'contain-absolute-path.zip');
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       await compressing.zip.uncompress(sourceFile, destDir, { strip: 1 });
       const names = fs.readdirSync(destDir);
       names.sort();
@@ -253,7 +253,7 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.uncompress(sourceStream, destDir)', async () => {
       const sourceStream = fs.createReadStream(path.join(__dirname, '..', 'fixtures', 'xxx.zip'));
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'xxx');
       await compressing.zip.uncompress(sourceStream, destDir);
       const res = dircompare.compareSync(originalDir, path.join(destDir, 'xxx'));
@@ -265,7 +265,7 @@ describe('test/zip/index.test.js', () => {
 
     it('zip.uncompress(sourceBuffer, destDir)', async () => {
       const sourceBuffer = fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'xxx.zip'));
-      destDir = path.join(os.tmpdir(), uuid.v4());
+      destDir = path.join(os.tmpdir(), randomUUID());
       const originalDir = path.join(__dirname, '..', 'fixtures', 'xxx');
       await compressing.zip.uncompress(sourceBuffer, destDir);
       const res = dircompare.compareSync(originalDir, path.join(destDir, 'xxx'));
@@ -278,13 +278,13 @@ describe('test/zip/index.test.js', () => {
   it('uncompress should keep stat mode', async () => {
     const sourceFile = path.join(__dirname, '..', 'fixtures/xxx/bin');
     const originStat = fs.statSync(sourceFile);
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     // console.log('dest', destFile);
     const fileStream = fs.createWriteStream(destFile);
     await compressing.zip.compressFile(sourceFile, fileStream);
     assert(fs.existsSync(destFile));
 
-    destDir = path.join(os.tmpdir(), uuid.v4());
+    destDir = path.join(os.tmpdir(), randomUUID());
     fs.mkdirSync(destDir, { recursive: true });
     await compressing.zip.uncompress(destFile, destDir);
     const stat = fs.statSync(path.join(destDir, 'bin'));

--- a/test/zip/stream.test.js
+++ b/test/zip/stream.test.js
@@ -4,7 +4,7 @@ const mm = require('mm');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const { pipeline: pump } = require('stream');
 const compressing = require('../..');
 const assert = require('assert');
@@ -14,7 +14,7 @@ describe('test/zip/stream.test.js', () => {
   afterEach(mm.restore);
 
   it('.addEntry(file)', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -30,7 +30,7 @@ describe('test/zip/stream.test.js', () => {
   });
 
   it('.addEntry(file, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -46,7 +46,7 @@ describe('test/zip/stream.test.js', () => {
   });
 
   it('.addEntry(dir)', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -62,7 +62,7 @@ describe('test/zip/stream.test.js', () => {
   });
 
   it('.addEntry(dir, { ignoreBase: true })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -78,7 +78,7 @@ describe('test/zip/stream.test.js', () => {
   });
 
   it('.addEntry(dir, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -94,7 +94,7 @@ describe('test/zip/stream.test.js', () => {
   });
 
   it('.addEntry(dir, { relativePath, ignoreBase: true })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -110,7 +110,7 @@ describe('test/zip/stream.test.js', () => {
   });
 
   it('.addEntry(buffer, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -124,7 +124,7 @@ describe('test/zip/stream.test.js', () => {
   });
 
   it('.addEntry(stream, { relativePath })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -142,7 +142,7 @@ describe('test/zip/stream.test.js', () => {
   });
 
   it('.addEntry(stream, { relativePath, size })', done => {
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 
@@ -163,7 +163,7 @@ describe('test/zip/stream.test.js', () => {
   it('.addEntry multiple times', done => {
     const sourceFile = path.join(__dirname, '..', 'fixtures', 'xx.log');
     const sourceDir = path.join(__dirname, '..', 'fixtures');
-    const destFile = path.join(os.tmpdir(), uuid.v4() + '.zip');
+    const destFile = path.join(os.tmpdir(), randomUUID() + '.zip');
     const fileStream = fs.createWriteStream(destFile);
     // console.log('dest', destFile);
 

--- a/test/zip/uncompress_stream.test.js
+++ b/test/zip/uncompress_stream.test.js
@@ -2,7 +2,7 @@ const mm = require('mm');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const uuid = require('uuid');
+const { randomUUID } = require('node:crypto');
 const assert = require('assert');
 const { pipeline: pump } = require('stream');
 const dircompare = require('dir-compare');
@@ -17,7 +17,7 @@ describe('test/zip/uncompress_stream.test.js', () => {
 
   it('should be a writable stream', done => {
     const sourceStream = fs.createReadStream(sourceFile);
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.zip.UncompressStream();
     fs.mkdirSync(destDir, { recursive: true });
@@ -56,7 +56,7 @@ describe('test/zip/uncompress_stream.test.js', () => {
   });
 
   it('should uncompress according to file path', done => {
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.zip.UncompressStream({ source: sourceFile });
     fs.mkdirSync(destDir, { recursive: true });
@@ -89,7 +89,7 @@ describe('test/zip/uncompress_stream.test.js', () => {
 
   it('should uncompress buffer', done => {
     const sourceBuffer = fs.readFileSync(sourceFile);
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.zip.UncompressStream({ source: sourceBuffer });
     fs.mkdirSync(destDir, { recursive: true });
@@ -122,7 +122,7 @@ describe('test/zip/uncompress_stream.test.js', () => {
 
   it('should uncompress stream', done => {
     const sourceStream = fs.createReadStream(sourceFile);
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.zip.UncompressStream({ source: sourceStream });
     fs.mkdirSync(destDir, { recursive: true });
@@ -186,7 +186,7 @@ describe('test/zip/uncompress_stream.test.js', () => {
 
   it('should uncompress with strip 1', done => {
     const sourceStream = fs.createReadStream(sourceFile);
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.zip.UncompressStream({ strip: 1 });
     fs.mkdirSync(destDir, { recursive: true });
@@ -217,7 +217,7 @@ describe('test/zip/uncompress_stream.test.js', () => {
 
   it('should uncompress with strip 2', done => {
     const sourceStream = fs.createReadStream(sourceFile);
-    const destDir = path.join(os.tmpdir(), uuid.v4());
+    const destDir = path.join(os.tmpdir(), randomUUID());
 
     const uncompressStream = new compressing.zip.UncompressStream({ strip: 2 });
     fs.mkdirSync(destDir, { recursive: true });


### PR DESCRIPTION
The uuid package was a devDependency only used to generate temp file names in tests. Node's built-in crypto.randomUUID() covers this since Node 14.17 and the package requires Node >= 18, so this drops the dependency entirely.

This also resolves the CVE-2026-41907 advisory flagged by Renovate, making #139 obsolete.

Verified with npm run lint and npm run test:js (171 passing, 3 pending).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the unused UUID development dependency.
  * Updated temporary test file and directory generation to use Node.js’s built-in UUID support.

* **Tests**
  * Preserved existing archive, extraction, streaming, and security test behavior while improving temporary path isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->