### PR TITLE
fix: replace @eggjs/yauzl with upstream yauzl 3.4.0, update yazl to 3.3.1

### DIFF
--- a/lib/tar/stream.js
+++ b/lib/tar/stream.js
@@ -127,9 +127,15 @@ class TarStream extends BaseStream {
     const waitingEntry = this._waitingEntries.shift();
     if (waitingEntry) {
       this.addEntry.apply(this, waitingEntry);
-    } else {
-      this._finalize();
+      return;
     }
+    // A caller adding entries back to back queues the later ones only after this
+    // returns, and for zip the finish callback runs synchronously, so finalizing
+    // here would close the archive after the first entry. Give the caller a tick.
+    setImmediate(() => {
+      if (this._processing || this._waitingEntries.length > 0) return;
+      this._finalize();
+    });
   }
 
   _finalize() {

--- a/lib/zip/uncompress_stream.js
+++ b/lib/zip/uncompress_stream.js
@@ -3,7 +3,7 @@
 // https://github.com/thejoshwolfe/yauzl#no-streaming-unzip-api
 
 const debug = require('util').debuglog('compressing/zip/uncompress_stream');
-const yauzl = require('@eggjs/yauzl');
+const yauzl = require('yauzl');
 const stream = require('stream');
 const UncompressBaseStream = require('../base_write_stream');
 const utils = require('../utils');

--- a/lib/zip/uncompress_stream.js
+++ b/lib/zip/uncompress_stream.js
@@ -125,7 +125,11 @@ class ZipUncompressStream extends UncompressBaseStream {
           const placeholder = new stream.Readable({ read() {} });
           debug('directory, header: %j', header);
           this.emit('entry', header, placeholder, next);
-          setImmediate(() => placeholder.emit('end'));
+          // Push EOF rather than emitting 'end' on a timer: a fabricated event fires
+          // whether or not the consumer has finished with the entry, so a listener
+          // that creates the directory asynchronously would see the next entry, a
+          // file inside that directory, arrive before the directory exists.
+          placeholder.push(null);
         }
       })
       .on('end', () => this._finalCallback())

--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
   },
   "homepage": "https://github.com/node-modules/compressing#readme",
   "dependencies": {
-    "yauzl": "^3.4.0",
     "flushwritable": "^1.0.0",
     "get-ready": "^1.0.0",
     "iconv-lite": "^0.7.0",
     "streamifier": "^0.1.1",
     "tar-stream": "^1.5.2",
-    "yazl": "^2.4.2"
+    "yauzl": "^3.4.0",
+    "yazl": "^3.3.1"
   },
   "devDependencies": {
     "@types/mocha": "10",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/node-modules/compressing#readme",
   "dependencies": {
-    "@eggjs/yauzl": "^2.11.0",
+    "yauzl": "^3.4.0",
     "flushwritable": "^1.0.0",
     "get-ready": "^1.0.0",
     "iconv-lite": "^0.7.0",

--- a/test/zip/uncompress_stream.test.js
+++ b/test/zip/uncompress_stream.test.js
@@ -52,7 +52,7 @@ describe('test/zip/uncompress_stream.test.js', () => {
     const uncompressStream = new compressing.zip.UncompressStream();
     await assert.rejects(async () => {
       await pipelinePromise(fs.createReadStream(sourceFile), uncompressStream);
-    }, /end of central directory record signature not found/);
+    }, /end of central directory record signature not found/i);
   });
 
   it('should uncompress according to file path', done => {


### PR DESCRIPTION
Fixes the Node 26 CI failure on master, and moves both zip dependencies to their upstream, maintained versions.

## yauzl: the Node 26 fix

`@eggjs/yauzl` depends on `fd-slicer2`, whose `ReadStream` loses data when piped on Node 26. Any zip entry over the 64 KiB `highWaterMark` delivers roughly the first chunk and then stalls, with no `end`, no `error`, no `close`. That is why `zip.uncompress()` hangs until the 60s timeout on Node 26 while passing on 18 through 24.

Not our code: released 2.1.1 reproduces it identically. Reported upstream at node-modules/yauzl#3.

`yauzl@3.4.0` dropped `fd-slicer` entirely (only dependency is now `pend`) and does not have the bug.

The fork was adopted for `decodeStrings: false` so absolute paths survive `validateFileName`. I checked that still holds against the `contain-absolute-path.zip` fixture rather than assuming:

| | @eggjs/yauzl 2.11.0 | upstream 3.4.0 |
| --- | --- | --- |
| entries | 31 | 31 |
| `fileName` is Buffer | 31 | 31 |
| `externalFileAttributes` present | 31 | 31 |
| files read | 21 | 21 |
| leading `/` entry | preserved | preserved |

Only visible difference: yauzl 3 capitalises the "End of central directory record signature not found" message, so that assertion is now case-insensitive.

## yazl 3 and the early-finalize bug it exposed

yazl 3 turns "add entries after calling `end()`" from a tolerated no-op into a thrown error, and compressing trips it immediately.

`_onEntryFinish()` finalizes as soon as the entry queue is momentarily empty. For zip the finish callback runs synchronously, so a caller doing:

```js
zipStream.addEntry(streamA, ...);
zipStream.addEntry(bufferB, ...);
```

closed the archive after the first entry, and the second threw. Tar avoids it only because its `fs.stat` makes the callback async, which lets the later entries queue first.

Worth being precise about the old behaviour: **yazl 2 did not drop those entries.** I checked, and the produced archive contained all of them. So this was latent, not a live data-loss bug.

Fix is to finalize on the next tick and skip it if an entry arrived meanwhile. Verified the produced archive still contains every entry.

Residual limitation, unchanged in spirit from before: entries added after a longer async gap still finalize early. That is the existing drain heuristic, and giving the stream an explicit "done adding" call would be an API change worth doing separately.

## Result

**171 passing on both Node 24 and Node 26**, lint and `tsc` clean. On Node 26 the zip suite finishes in ~495ms where it previously hung for 60s. The symlink cases from #140 were re-checked through the new zip path and still block.

Drops `fd-slicer2` and `buffer-crc32` from the tree. Supersedes #132.